### PR TITLE
Change `std::env::var` to `env!`

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,8 @@ use tracing_subscriber::{
     self, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, Layer,
 };
 
+pub static GIT_COMMIT_HASH: &'static str = env!("SHUTTLE_TUI_GIT_INFO");
+
 lazy_static! {
     pub static ref PROJECT_NAME: String = env!("CARGO_CRATE_NAME").to_uppercase().to_string();
     pub static ref DATA_FOLDER: Option<PathBuf> =
@@ -19,9 +21,6 @@ lazy_static! {
         std::env::var(format!("{}_CONFIG", PROJECT_NAME.clone()))
             .ok()
             .map(PathBuf::from);
-    pub static ref GIT_COMMIT_HASH: String =
-        std::env::var(format!("{}_GIT_INFO", PROJECT_NAME.clone()))
-            .unwrap_or_else(|_| String::from("UNKNOWN"));
     pub static ref LOG_ENV: String = format!("{}_LOGLEVEL", PROJECT_NAME.clone());
     pub static ref LOG_FILE: String = format!("{}.log", env!("CARGO_PKG_NAME"));
 }
@@ -158,7 +157,7 @@ macro_rules! trace_dbg {
 pub fn version() -> String {
     let author = clap::crate_authors!();
 
-    let commit_hash = GIT_COMMIT_HASH.clone();
+    let commit_hash = GIT_COMMIT_HASH;
 
     // let current_exe_path = PathBuf::from(clap::crate_name!()).display().to_string();
     let config_dir_path = get_config_dir().display().to_string();


### PR DESCRIPTION
`SHUTTLE_TUI_GIT_INFO` is a compile time environment variable

https://github.com/shuttle-hq/shuttle-tui/blob/890e5a5a217b655e99fc4cad9650c11242dc33ce/build.rs#L54

but `std::env::var` only reads run time values.

This was a bug in the template: https://github.com/ratatui-org/async-template/issues/18
